### PR TITLE
clearing xattr during build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,9 @@ var gulpif = require('gulp-if');
 var gulpFilter = require('gulp-filter');
 var stripDebug = require('gulp-strip-debug');
 var uglify = require('gulp-uglify');
+var shell = require('gulp-shell');
 var del = require('delete-empty');
+var runSequence = require('run-sequence');
 
 var lintFiles = ['Source/**/*.js', '!Source/**/*.min.js', '!Source/Chrome/background/google-maps-api.js'];
 
@@ -132,6 +134,10 @@ gulp.task('localesSafari', function() {
 	  .pipe(gulp.dest(safariBuildpath + '_locales'));
 });
 
+gulp.task('clearXAttr', shell.task([
+  'xattr -rc ' + safariBuildpath
+]));
+
 gulp.task('cleanChrome',function() {
   return del.sync(chormeBuildpath);
 });
@@ -146,7 +152,13 @@ gulp.task('cleanFirefox',function() {
 
 gulp.task('groupFirefox', ['cleanFirefox','localesFF', 'coreFirefox', 'specificFirefox']);
 gulp.task('groupChrome', ['cleanChrome','localesChrome', 'coreChrome', 'specificChrome']);
-gulp.task('groupSafari', ['cleanSafari','localesSafari', 'coreSafari', 'chromeShared','specificSafari']);
+gulp.task('copySafariFiles', ['localesSafari', 'coreSafari', 'chromeShared','specificSafari']);
+
+gulp.task('groupSafari', function(done) {
+  runSequence('cleanSafari', 'copySafariFiles', 'clearXAttr', function() {
+    done();
+  });
+});
 
 gulp.task('group', ['groupChrome', 'groupFirefox', 'groupSafari']);
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "gulp-if": "^2.0.1",
     "gulp-filter": "^4.0.0",
     "gulp-uglify": "^2.0.0",
-    "delete-empty": "^0.1.3"
+    "delete-empty": "^0.1.3",
+    "gulp-shell": "^0.5.2",
+    "run-sequence": "1.2.2"
   }
 }


### PR DESCRIPTION
Hi @Ceilican,

It's weird that I wasn't able to find any extended attributes before using "xattr -rc". Perhaps I am overlooking something. Maybe you'd need to install **xattr** if not present.

I hope it gets accepted this time.